### PR TITLE
Unify imports to not end up with two color picker contexts

### DIFF
--- a/src/components/_common/Swatch.tsx
+++ b/src/components/_common/Swatch.tsx
@@ -1,6 +1,6 @@
 import { createSignal, JSX, mergeProps } from 'solid-js'
 import { Checkboard } from './Checkboard'
-import { useColorPicker } from './ColorPicker'
+import { useColorPicker } from '.'
 
 const ENTER = 13
 

--- a/src/components/hue/Hue.tsx
+++ b/src/components/hue/Hue.tsx
@@ -1,4 +1,4 @@
-import { useColorPicker, withColorPicker } from '../_common/ColorPicker'
+import { useColorPicker, withColorPicker } from '../_common'
 import { ChangeColor } from '../../types'
 import { Hue } from '../_common'
 import HuePointer from './HuePointer'

--- a/src/components/material/Material.tsx
+++ b/src/components/material/Material.tsx
@@ -1,8 +1,7 @@
 import { merge } from 'lodash-es'
 import { JSX, mergeProps } from 'solid-js'
 import { ChangeColor, RgbColor } from '../../types'
-import { EditableInput, Raised } from '../_common'
-import { useColorPicker, withColorPicker } from '../_common/ColorPicker'
+import { EditableInput, Raised, useColorPicker, withColorPicker } from '../_common'
 import { isValidHex } from '../../helpers/color'
 
 export type MaterialPickerProps = {


### PR DESCRIPTION
`useColorPicker` is imported both from `_common/ColorPicker` and `_common`, which is treated as two different imports and therefore results in the SolidJS context not being available in some places.

This PR unifies the imports and resolves the runtime issues.